### PR TITLE
WMS-129 implementare spostamento camera con tastiera

### DIFF
--- a/web/components/ThreeComponents/CameraController.tsx
+++ b/web/components/ThreeComponents/CameraController.tsx
@@ -5,12 +5,13 @@ import { useFloorData } from "../providers/floorProvider";
 import { useState } from "react";
 
 interface CameraControllerProps {
-	setIsNavigating?: (boolean: boolean) => void;
-	setCameraPosition?: (position: Vector3) => void;
+	setIsNavigating: (boolean: boolean) => void;
+	setCameraPosition: (position: Vector3) => void;
 }
 
 export function CameraController({
 	setIsNavigating,
+	setCameraPosition
 }: CameraControllerProps) {
 
 	const [,get] = useKeyboardControls();

--- a/web/components/ThreeComponents/CameraController.tsx
+++ b/web/components/ThreeComponents/CameraController.tsx
@@ -17,10 +17,9 @@ export function CameraController({
 
 	useFrame((state) => {
 		const { forward, backward, left, right, quick } = get()
+		const moveSpeed = quick ? 0.75 : 0.25;
 
 		setIsNavigating(forward || backward || left || right || false);
-
-		const moveSpeed = quick ? 0.75 : 0.25;
 
 		state.camera.position.set(
 			camera.camera.position.x + (right ? moveSpeed : 0) + (left ? -moveSpeed : 0),
@@ -29,6 +28,7 @@ export function CameraController({
 		);
 
 		setCameraPosition(state.camera.position);
+		state.camera.updateProjectionMatrix();
 	});
 	return (
 		<></>

--- a/web/components/ThreeComponents/CameraController.tsx
+++ b/web/components/ThreeComponents/CameraController.tsx
@@ -1,8 +1,6 @@
 import { useKeyboardControls } from "@react-three/drei";
 import { useFrame, useThree } from "@react-three/fiber";
 import { Vector3 } from "three";
-import { useFloorData } from "../providers/floorProvider";
-import { useState } from "react";
 
 interface CameraControllerProps {
 	setIsNavigating: (boolean: boolean) => void;
@@ -16,27 +14,23 @@ export function CameraController({
 
 	const [,get] = useKeyboardControls();
 	const camera = useThree();
-	const { floor } = useFloorData();
-	const moveSpeed = 0.25;
 
-	const [cameraPosition, setCameraPosition] = useState(camera.camera.position.clone());
-
-	useFrame(() => {
+	useFrame((state) => {
 		const { forward, backward, left, right, quick } = get()
+
 		setIsNavigating(forward || backward || left || right || false);
 
-		const speedModifier = quick ? 3 : 1;
-		const movement = new Vector3(
-			(right ? moveSpeed*speedModifier : 0) + (left ? -moveSpeed*speedModifier : 0),
-			0,
-			(backward ? moveSpeed*speedModifier : 0) + (forward ? -moveSpeed*speedModifier : 0)
+		const moveSpeed = quick ? 0.75 : 0.25;
+
+		state.camera.position.set(
+			camera.camera.position.x + (right ? moveSpeed : 0) + (left ? -moveSpeed : 0),
+			camera.camera.position.y,
+			camera.camera.position.z + (backward ? moveSpeed : 0) + (forward ? -moveSpeed : 0)
 		);
 
-		const newCameraPosition = camera.camera.position.clone().add(movement);
-		setCameraPosition(newCameraPosition);
-
-		camera.camera.position.copy(newCameraPosition);
-	})
-	console.log('Current camera position:', cameraPosition);
-	return null;
+		setCameraPosition(state.camera.position);
+	});
+	return (
+		<></>
+	);
 }

--- a/web/components/ThreeComponents/CameraController.tsx
+++ b/web/components/ThreeComponents/CameraController.tsx
@@ -1,53 +1,28 @@
 import { CameraControls, useKeyboardControls } from "@react-three/drei";
-import { useFrame, useThree } from "@react-three/fiber";
-import { Ref, RefObject } from "react";
-import { Camera, Vector3 } from "three";
+import { useFrame } from "@react-three/fiber";
+import { RefObject } from "react";
 
 interface CameraControllerProps {
-	setIsNavigating: (boolean: boolean) => void;
-	setCameraPosition: (position: Vector3) => void;
 	cameraRef: RefObject<CameraControls>;
 }
 
 export function CameraController({
-	setIsNavigating,
-	setCameraPosition,
 	cameraRef,
 }: CameraControllerProps) {
 
 	const [,get] = useKeyboardControls();
-	const {camera } = useThree();
-	let prevTarget = new Vector3(); // Store the previous target
 
-	useFrame((state) => {
+	useFrame(() => {
+
 		const { forward, backward, left, right, quick } = get();
+
 		const moveSpeed = quick ? 0.75 : 0.25;
-		const target = new Vector3(); // The point to look at
-	
-		// Update position
-		camera.position.set(
-			camera.position.x + (right ? moveSpeed : 0) + (left ? -moveSpeed : 0),
-			camera.position.y,
-			camera.position.z + (backward ? moveSpeed : 0) + (forward ? -moveSpeed : 0)
-		);
-	
-		// Update target based on its previous position and the direction of movement
-		target.set(
-			prevTarget.x + (right ? moveSpeed : 0) + (left ? -moveSpeed : 0),
-			prevTarget.y,
-			prevTarget.z + (backward ? moveSpeed : 0) + (forward ? -moveSpeed : 0)
-		);
-	
-		camera.lookAt(target);
-	
-		// Store the current target for the next frame
-		prevTarget.copy(target);
-	
-		cameraRef.current?.setPosition(camera.position.x, camera.position.y, camera.position.z);
+
+		cameraRef.current?.forward((forward ? moveSpeed : 0) + (backward ? -moveSpeed : 0));
+		cameraRef.current?.truck((right ? moveSpeed : 0) + (left ? -moveSpeed : 0), 0);
+
 	});
-	
-	
-	
+
 	return (
 		<></>
 	);

--- a/web/components/ThreeComponents/CameraController.tsx
+++ b/web/components/ThreeComponents/CameraController.tsx
@@ -1,35 +1,53 @@
-import { useKeyboardControls } from "@react-three/drei";
+import { CameraControls, useKeyboardControls } from "@react-three/drei";
 import { useFrame, useThree } from "@react-three/fiber";
-import { Vector3 } from "three";
+import { Ref, RefObject } from "react";
+import { Camera, Vector3 } from "three";
 
 interface CameraControllerProps {
 	setIsNavigating: (boolean: boolean) => void;
 	setCameraPosition: (position: Vector3) => void;
+	cameraRef: RefObject<CameraControls>;
 }
 
 export function CameraController({
 	setIsNavigating,
-	setCameraPosition
+	setCameraPosition,
+	cameraRef,
 }: CameraControllerProps) {
 
 	const [,get] = useKeyboardControls();
-	const camera = useThree();
+	const {camera } = useThree();
+	let prevTarget = new Vector3(); // Store the previous target
 
 	useFrame((state) => {
-		const { forward, backward, left, right, quick } = get()
+		const { forward, backward, left, right, quick } = get();
 		const moveSpeed = quick ? 0.75 : 0.25;
-
-		setIsNavigating(forward || backward || left || right || false);
-
-		state.camera.position.set(
-			camera.camera.position.x + (right ? moveSpeed : 0) + (left ? -moveSpeed : 0),
-			camera.camera.position.y,
-			camera.camera.position.z + (backward ? moveSpeed : 0) + (forward ? -moveSpeed : 0)
+		const target = new Vector3(); // The point to look at
+	
+		// Update position
+		camera.position.set(
+			camera.position.x + (right ? moveSpeed : 0) + (left ? -moveSpeed : 0),
+			camera.position.y,
+			camera.position.z + (backward ? moveSpeed : 0) + (forward ? -moveSpeed : 0)
 		);
-
-		setCameraPosition(state.camera.position);
-		state.camera.updateProjectionMatrix();
+	
+		// Update target based on its previous position and the direction of movement
+		target.set(
+			prevTarget.x + (right ? moveSpeed : 0) + (left ? -moveSpeed : 0),
+			prevTarget.y,
+			prevTarget.z + (backward ? moveSpeed : 0) + (forward ? -moveSpeed : 0)
+		);
+	
+		camera.lookAt(target);
+	
+		// Store the current target for the next frame
+		prevTarget.copy(target);
+	
+		cameraRef.current?.setPosition(camera.position.x, camera.position.y, camera.position.z);
 	});
+	
+	
+	
 	return (
 		<></>
 	);

--- a/web/components/ThreeComponents/CameraController.tsx
+++ b/web/components/ThreeComponents/CameraController.tsx
@@ -1,0 +1,41 @@
+import { useKeyboardControls } from "@react-three/drei";
+import { useFrame, useThree } from "@react-three/fiber";
+import { Vector3 } from "three";
+import { useFloorData } from "../providers/floorProvider";
+import { useState } from "react";
+
+interface CameraControllerProps {
+	setIsNavigating?: (boolean: boolean) => void;
+	setCameraPosition?: (position: Vector3) => void;
+}
+
+export function CameraController({
+	setIsNavigating,
+}: CameraControllerProps) {
+
+	const [,get] = useKeyboardControls();
+	const camera = useThree();
+	const { floor } = useFloorData();
+	const moveSpeed = 0.25;
+
+	const [cameraPosition, setCameraPosition] = useState(camera.camera.position.clone());
+
+	useFrame(() => {
+		const { forward, backward, left, right, quick } = get()
+		setIsNavigating(forward || backward || left || right || false);
+
+		const speedModifier = quick ? 3 : 1;
+		const movement = new Vector3(
+			(right ? moveSpeed*speedModifier : 0) + (left ? -moveSpeed*speedModifier : 0),
+			0,
+			(backward ? moveSpeed*speedModifier : 0) + (forward ? -moveSpeed*speedModifier : 0)
+		);
+
+		const newCameraPosition = camera.camera.position.clone().add(movement);
+		setCameraPosition(newCameraPosition);
+
+		camera.camera.position.copy(newCameraPosition);
+	})
+	console.log('Current camera position:', cameraPosition);
+	return null;
+}

--- a/web/components/ThreeComponents/ExtendedCameraControls.tsx
+++ b/web/components/ThreeComponents/ExtendedCameraControls.tsx
@@ -2,13 +2,13 @@ import { CameraControls, useKeyboardControls } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
 import { RefObject } from "react";
 
-interface CameraControllerProps {
+interface ExtendedCameraControlsProps {
 	cameraRef: RefObject<CameraControls>;
 }
 
-export function CameraController({
+export function ExtendedCameraControls({
 	cameraRef,
-}: CameraControllerProps) {
+}: ExtendedCameraControlsProps) {
 
 	const [,get] = useKeyboardControls();
 

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -6,7 +6,7 @@ import { Vector3 } from "three";
 import { useZonesData } from "../providers/zonesProvider";
 import { Zone } from "@/model/zone";
 import { Zone3D } from "./Model3D/zone3D";
-import { CameraController } from "./CameraController";
+import { ExtendedCameraControls } from "./ExtendedCameraControls";
 import { useRef, useState } from "react";
 
 export default function Warehouse() {
@@ -60,7 +60,7 @@ export default function Warehouse() {
 					ref={cameraRef}
 					/>
 
-				<CameraController
+				<ExtendedCameraControls
 					cameraRef={cameraRef}
 					/>
 			</Canvas>

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -30,7 +30,6 @@ export default function Warehouse() {
 				className={"h-screen, w-screen, bg-BurlyWood"}
 				camera={{
 					position: [cameraPosition.x, cameraPosition.y, cameraPosition.z],
-					rotation: [Math.PI / 2, Math.PI / 2, Math.PI / 2]
 				}}>
 
 				<Floor />

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -1,50 +1,83 @@
 import { Canvas, useThree } from "@react-three/fiber";
-import { OrbitControls, PerspectiveCamera } from "@react-three/drei";
+import { KeyboardControls, OrbitControls, PerspectiveCamera } from "@react-three/drei";
 import Floor from "./Model3D/Floor";
 import { useFloorData } from "../providers/floorProvider";
-import THREE, { Raycaster, Vector2, Vector3 } from "three";
+import { Camera, Vector3 } from "three";
 import { useZonesData } from "../providers/zonesProvider";
 import { Zone } from "@/model/zone";
 import { Zone3D } from "./Model3D/zone3D";
 import { useWarehouseData } from "../providers/Threejs/warehouseProvider";
+import { useState } from "react";
+import { CameraController } from "./CameraController";
 
 export default function Warehouse() {
 	const { floor } = useFloorData();
 	const { zones } = useZonesData();
 
-	const {isDragging} = useWarehouseData();
+	const [isDragging, setIsDragging] = useState(false);
+	const [isNavigating, setIsNavigating] = useState(false);
+	// const [cameraPosition, setCameraPosition] = useState({ x: 0, y: 0, z: 0 });
+
+	console.log(setIsNavigating);
+	console.log(isNavigating);
 
 	return (
-		<Canvas className={"h-screen, bg-BurlyWood"}>
-			<PerspectiveCamera
-				makeDefault
-				position={[floor.getWidth() / 2, 60, floor.getLength()]}
-				rotation={[Math.PI / 2, Math.PI / 2, Math.PI / 2]}
-			/>
-			<Floor />
-
-			{zones.map((zone: Zone, index: number) => {
-				const zonePosition = new Vector3(
-					zone.getXcoordinate(),
-					0,
-					zone.getYcoordinate()
-				);
-				return (
-					<Zone3D
-						key={zone.getId()}
-						zone={zone}
-						position={zonePosition}
+		<KeyboardControls
+			map={[
+				{ name: "forward", keys: ["ArrowUp", "w", "W"] },
+				{ name: "backward", keys: ["ArrowDown", "s", "S"] },
+				{ name: "left", keys: ["ArrowLeft", "a", "A"] },
+				{ name: "right", keys: ["ArrowRight", "d", "D"] },
+				{ name: "quick", keys: ["ShiftLeft", "ShiftRight"]}
+			]}>
+			<Canvas className={"h-screen, bg-BurlyWood"}>
+				<PerspectiveCamera
+					makeDefault
+					position={[floor.getWidth() / 2, 60, floor.getLength()]}
+					rotation={[Math.PI / 2, Math.PI / 2, Math.PI / 2]}
 					/>
-				);
-			})}
 
-			<OrbitControls
-				dampingFactor={0.05}
+				<Floor />
+
+				{zones.map((zone: Zone, index: number) => {
+					const zonePosition = new Vector3(
+						zone.getXcoordinate(),
+						0,
+						zone.getYcoordinate()
+						);
+						return (
+							<Zone3D
+								key={zone.getId()}
+								zone={zone}
+								position={zonePosition}
+								setIsDragging={setIsDragging}
+							/>
+							);
+						})}
+
+				{/* <OrbitControls
+					minAzimuthAngle={-Math.PI / 3}
+					maxAzimuthAngle={Math.PI / 3}
+					enablePan={true}
+					enabled={!isDragging && !isNavigating}
+				/> */}
+
+				<OrbitControls
 				screenSpacePanning={false}
-				minPolarAngle={Math.PI / 5}
-				maxPolarAngle={Math.PI / 2.3}
-				enabled={!isDragging}
-			/>
-		</Canvas>
+					minPolarAngle={Math.PI / 5}
+					maxPolarAngle={Math.PI / 2.3}
+					maxDistance={100}
+					minDistance={5}
+					dampingFactor={0.05}
+					zoomSpeed={2}
+					enabled={!isDragging && !isNavigating}
+					/>
+
+				<CameraController
+					setIsNavigating={setIsNavigating}
+					// setCameraPosition={setCameraPosition}
+					/>
+			</Canvas>
+		</KeyboardControls>
 	);
 }

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -54,21 +54,16 @@ export default function Warehouse() {
 							);
 						})}
 
-				{/* <OrbitControls
-					minAzimuthAngle={-Math.PI / 3}
-					maxAzimuthAngle={Math.PI / 3}
-					enablePan={true}
-					enabled={!isDragging && !isNavigating}
-				/> */}
-
-				<OrbitControls
-				screenSpacePanning={false}
-					minPolarAngle={Math.PI / 5}
-					maxPolarAngle={Math.PI / 2.3}
-					maxDistance={100}
+				<CameraControls
+					minPolarAngle={Math.PI / 10}
+					maxPolarAngle={Math.PI / 3}
 					minDistance={5}
-					dampingFactor={0.05}
-					zoomSpeed={2}
+					maxDistance={100}
+					minZoom={5}
+					maxZoom={100}
+					dollySpeed={1}
+					dollyDragInverted
+					dollyToCursor
 					enabled={!isDragging && !isNavigating}
 					/>
 

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -22,9 +22,9 @@ export default function Warehouse() {
 			map={[
 				{ name: "forward", keys: ["ArrowUp", "w", "W"] },
 				{ name: "backward", keys: ["ArrowDown", "s", "S"] },
-				{ name: "left", keys: ["ArrowLeft", "a", "A"] },
+				{ name: "left",	keys: ["ArrowLeft", "a", "A"] },
 				{ name: "right", keys: ["ArrowRight", "d", "D"] },
-				{ name: "quick", keys: ["ShiftLeft", "ShiftRight"]}
+				{ name: "quick", keys: ["ShiftLeft", "ShiftRight"] },
 			]}>
 			<Canvas
 				className={"h-screen, w-screen, bg-BurlyWood"}

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -15,10 +15,7 @@ export default function Warehouse() {
 
 	const [isDragging, setIsDragging] = useState(false);
 	const [isNavigating, setIsNavigating] = useState(false);
-	// const [cameraPosition, setCameraPosition] = useState({ x: 0, y: 0, z: 0 });
-
-	console.log(setIsNavigating);
-	console.log(isNavigating);
+	const [cameraPosition, setCameraPosition] = useState({ x: floor.getWidth(), y: 60, z: floor.getLength() });
 
 	return (
 		<KeyboardControls
@@ -69,7 +66,7 @@ export default function Warehouse() {
 
 				<CameraController
 					setIsNavigating={setIsNavigating}
-					// setCameraPosition={setCameraPosition}
+					setCameraPosition={setCameraPosition}
 					/>
 			</Canvas>
 		</KeyboardControls>

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -29,12 +29,12 @@ export default function Warehouse() {
 				{ name: "right", keys: ["ArrowRight", "d", "D"] },
 				{ name: "quick", keys: ["ShiftLeft", "ShiftRight"]}
 			]}>
-			<Canvas className={"h-screen, bg-BurlyWood"}>
-				<PerspectiveCamera
-					makeDefault
-					position={[floor.getWidth() / 2, 60, floor.getLength()]}
-					rotation={[Math.PI / 2, Math.PI / 2, Math.PI / 2]}
-					/>
+			<Canvas
+				className={"h-screen, w-screen, bg-BurlyWood"}
+				camera={{
+					position: [cameraPosition.x, cameraPosition.y, cameraPosition.z],
+					rotation: [Math.PI / 2, Math.PI / 2, Math.PI / 2]
+				}}>
 
 				<Floor />
 

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -1,14 +1,13 @@
-import { Canvas, useThree } from "@react-three/fiber";
-import { KeyboardControls, OrbitControls, PerspectiveCamera } from "@react-three/drei";
+import { Canvas } from "@react-three/fiber";
+import { CameraControls, KeyboardControls, OrthographicCamera, PerspectiveCamera } from "@react-three/drei";
 import Floor from "./Model3D/Floor";
 import { useFloorData } from "../providers/floorProvider";
-import { Camera, Vector3 } from "three";
+import { Vector3 } from "three";
 import { useZonesData } from "../providers/zonesProvider";
 import { Zone } from "@/model/zone";
 import { Zone3D } from "./Model3D/zone3D";
-import { useWarehouseData } from "../providers/Threejs/warehouseProvider";
-import { useState } from "react";
 import { CameraController } from "./CameraController";
+import { useState } from "react";
 
 export default function Warehouse() {
 	const { floor } = useFloorData();

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -7,7 +7,7 @@ import { useZonesData } from "../providers/zonesProvider";
 import { Zone } from "@/model/zone";
 import { Zone3D } from "./Model3D/zone3D";
 import { CameraController } from "./CameraController";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 export default function Warehouse() {
 	const { floor } = useFloorData();
@@ -16,6 +16,7 @@ export default function Warehouse() {
 	const [isDragging, setIsDragging] = useState(false);
 	const [isNavigating, setIsNavigating] = useState(false);
 	const [cameraPosition, setCameraPosition] = useState({ x: floor.getWidth(), y: 60, z: floor.getLength() });
+	let cameraRef = useRef<CameraControls>(null);
 
 	return (
 		<KeyboardControls
@@ -45,7 +46,7 @@ export default function Warehouse() {
 								key={zone.getId()}
 								zone={zone}
 								position={zonePosition}
-								setIsDragging={setIsDragging}
+								//setIsDragging={setIsDragging}
 							/>
 							);
 						})}
@@ -57,15 +58,14 @@ export default function Warehouse() {
 					maxDistance={100}
 					minZoom={5}
 					maxZoom={100}
-					dollySpeed={1}
-					dollyDragInverted
-					dollyToCursor
 					enabled={!isDragging && !isNavigating}
+					ref={cameraRef}
 					/>
 
 				<CameraController
 					setIsNavigating={setIsNavigating}
 					setCameraPosition={setCameraPosition}
+					cameraRef={cameraRef}
 					/>
 			</Canvas>
 		</KeyboardControls>

--- a/web/components/ThreeComponents/Warehouse.tsx
+++ b/web/components/ThreeComponents/Warehouse.tsx
@@ -14,8 +14,6 @@ export default function Warehouse() {
 	const { zones } = useZonesData();
 
 	const [isDragging, setIsDragging] = useState(false);
-	const [isNavigating, setIsNavigating] = useState(false);
-	const [cameraPosition, setCameraPosition] = useState({ x: floor.getWidth(), y: 60, z: floor.getLength() });
 	let cameraRef = useRef<CameraControls>(null);
 
 	return (
@@ -30,7 +28,7 @@ export default function Warehouse() {
 			<Canvas
 				className={"h-screen, w-screen, bg-BurlyWood"}
 				camera={{
-					position: [cameraPosition.x, cameraPosition.y, cameraPosition.z],
+					position: [floor.getWidth(), 60, floor.getLength()],
 				}}>
 
 				<Floor />
@@ -58,13 +56,11 @@ export default function Warehouse() {
 					maxDistance={100}
 					minZoom={5}
 					maxZoom={100}
-					enabled={!isDragging && !isNavigating}
+					enabled={!isDragging}
 					ref={cameraRef}
 					/>
 
 				<CameraController
-					setIsNavigating={setIsNavigating}
-					setCameraPosition={setCameraPosition}
 					cameraRef={cameraRef}
 					/>
 			</Canvas>


### PR DESCRIPTION
### Note

`@drei/CameraControls` è un wrapper della libreria [camera-controls](https://github.com/yomotsu/camera-controls). Indovina un po', bastava usare i comandi nativi.

- Implementata navigazione con tastiera (WASD, frecce direzionali + modificatore di velocità)
- La direzione di spostamento è riferita alla posizione dello spettatore (aka la camera)
- Rimossi import statement, hook non usati

@Carraro-Riccardo lascio a te la gestione del merge per l'uso di `isDragging`. Ho visto che l'hai commentato.

### Checklist

- [x] push di un commit `#minor`, `#patch`;
- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
