### PR TITLE
WMS-145 Permettere spostamento camera con tastiera durante il trascinamento degli elementi

### DIFF
--- a/web/components/ThreeComponents/ExtendedCameraControls.tsx
+++ b/web/components/ThreeComponents/ExtendedCameraControls.tsx
@@ -14,13 +14,11 @@ export function ExtendedCameraControls({
 
 	useFrame(() => {
 
-		if(cameraRef.current?.enabled) {
-			const { forward, backward, left, right, quick } = get();
-			const moveSpeed = quick ? 0.75 : 0.25;
+		const { forward, backward, left, right, quick } = get();
+		const moveSpeed = quick ? 0.75 : 0.25;
 
-			cameraRef.current?.forward((forward ? moveSpeed : 0) + (backward ? -moveSpeed : 0));
-			cameraRef.current?.truck((right ? moveSpeed : 0) + (left ? -moveSpeed : 0), 0);
-		}
+		cameraRef.current?.forward((forward ? moveSpeed : 0) + (backward ? -moveSpeed : 0));
+		cameraRef.current?.truck((right ? moveSpeed : 0) + (left ? -moveSpeed : 0), 0);
 
 	});
 

--- a/web/components/ThreeComponents/Model3D/zone3D.tsx
+++ b/web/components/ThreeComponents/Model3D/zone3D.tsx
@@ -75,7 +75,7 @@ export function Zone3D({
 	const bind = useDrag((state) => {
 		state.event.stopPropagation();
 		if (toDrag && planeRef.current) {
-		  orbitRef.current.enabled = false;
+		  orbitRef.current.disconnect();
 		  planeRef.current.visible = true;
 		  const target = calculateTargetPosition(state);
 		  const collision = checkCollision();
@@ -93,7 +93,7 @@ export function Zone3D({
 		  if (state.last) {
 			planeRef.current.visible = false;
 			state.event.stopPropagation();
-			orbitRef.current.enabled = true;
+			orbitRef.current.connect();
 			setToDrag(false);
 
 			if (checkCollision()) {


### PR DESCRIPTION
### Note

- Rimosso blocco aggiornamento posizione camera
- Disconnette eventi mouse se rileva trascinamento

### Checklist

- [x] push di un commit `#minor`, `#patch`;
- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
