### PR TITLE
WMS-153 Fix calcolo lato maggiore SVG

### DIFF
--- a/web/Strategy/FloorStrategy.tsx
+++ b/web/Strategy/FloorStrategy.tsx
@@ -16,7 +16,7 @@ export class StandardFloorStrategy implements FloorStrategy {
 
 export class CustomFloorStrategy implements FloorStrategy {
     async createFloor(params: URLSearchParams): Promise<Floor> {
-        const length = parseInt(params.get("latoMaggiore") || "0");
+        const inputSide = parseInt(params.get("latoMaggiore") || "0");
         const svgString = await readSavedSVG();
         const parser = new DOMParser();
         const svgDoc = parser.parseFromString(svgString, 'image/svg+xml');
@@ -38,8 +38,13 @@ export class CustomFloorStrategy implements FloorStrategy {
             svgHeight = 1;
         }
 
-        const width = length * (svgWidth / svgHeight);
-        return new Floor(length, width, svgString);
+        const aspectRatio = svgWidth / svgHeight;
+        const calculateSide = inputSide / aspectRatio;
+
+        //se l'aspect ratio è maggiore di 1, allora il lato maggiore (inserito dall'utente) è la lunghezza
+        return new Floor( aspectRatio >= 1 ? calculateSide : inputSide, aspectRatio >= 1? inputSide : calculateSide, svgString);
+
+        //input order: length, width
     }
 }
 


### PR DESCRIPTION
### Note
WMS-153

@ggardin Ti chiedo domani di dirmi la tua su come ho impostato il calcolo. L'idea alla base è che se ti ho chiesto il lato maggiore in input, allora poi guardando la width e l'height prese dal file, io possa attribuire al valore maggiore il valore inserito all'utente, e all'altro il valore calcolato in base al ratio width/height

### Checklist

- [x] push di un commit `#minor`, `#patch`;
- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
