### PR TITLE
WMS-146 Integrare coverage report

### DIFF
--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -46,6 +46,7 @@ jobs:
       id: coverage
       run: |
         echo 'MD_REPORT<<EOF' >> $GITHUB_OUTPUT
+        echo "### Code Coverage" >> $GITHUB_OUTPUT
         cat "./coverage/coverage.txt" >> $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
     - name: Add coverage report to the PR

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -53,5 +53,5 @@ jobs:
         message: ${{ steps.coverage.outputs.markdownReport }}
     - name: Add coverage report to the job summary
       run: |
-        echo "## Code Coverage" >> $GITHUB_STEP_SUMMARY
+        echo "### Code Coverage" >> $GITHUB_STEP_SUMMARY
         echo "${{ steps.coverage.outputs.markdownReport }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -2,7 +2,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: 
+    branches:
       - dev
   pull_request:
     branches:
@@ -42,3 +42,16 @@ jobs:
         coveralls --version
     - name: Report coverage to Coveralls
       run: coveralls report ./coverage/lcov.info
+    - name: Convert coverage report to markdown
+      uses: fingerprintjs/action-coverage-report-md@v2
+      id: coverage
+      with:
+        textReportPath: './coverage/coverage.txt'
+    - name: Add coverage report to the PR
+      uses: mshick/add-pr-comment@v2
+      with:
+        message: ${{ steps.coverage.outputs.markdownReport }}
+    - name: Add coverage report to the job summary
+      run: |
+        echo "## Code Coverage" >> $GITHUB_STEP_SUMMARY
+        echo "${{ steps.coverage.outputs.markdownReport }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -2,7 +2,7 @@ name: Node.js CI
 
 on:
   push:
-    branches:
+    branches: 
       - dev
   pull_request:
     branches:
@@ -35,3 +35,10 @@ jobs:
       run: npm run build --if-present
     - name: Run test suite
       run: npm test
+    - name: Install Coveralls
+      run: |
+        curl -L https://coveralls.io/coveralls-linux.tar.gz | tar -xz -C /usr/local/bin
+        chmod +x /usr/local/bin/coveralls
+        coveralls --version
+    - name: Report coverage to Coveralls
+      run: coveralls report ./coverage/lcov.info

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -46,6 +46,7 @@ jobs:
       uses: fingerprintjs/action-coverage-report-md@v2
       id: coverage
       with:
+        srcBasePath: './'
         textReportPath: './coverage/coverage.txt'
     - name: Add coverage report to the PR
       uses: mshick/add-pr-comment@v2

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -46,7 +46,7 @@ jobs:
       uses: fingerprintjs/action-coverage-report-md@v2
       id: coverage
       with:
-        srcBasePath: './'
+        srcBasePath: './web'
         textReportPath: './coverage/coverage.txt'
     - name: Add coverage report to the PR
       uses: mshick/add-pr-comment@v2

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -44,7 +44,10 @@ jobs:
       run: coveralls report ./coverage/lcov.info -r ${{ secrets.COVERALLS_REPO_TOKEN}}
     - name: Convert coverage report to markdown
       id: coverage
-      run: echo "MD_REPORT=$(cat "./coverage/coverage.txt")" >> $GITHUB_OUTPUT
+      run: |
+        echo 'MD_REPORT<<EOF' >> $GITHUB_OUTPUT
+        cat "./coverage/coverage.txt" >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
     - name: Add coverage report to the PR
       uses: mshick/add-pr-comment@v2
       with:

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 21.x]
+        node-version: [18.x, 20.x, 21.x]
 
     steps:
     - name: Checkout repo

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -41,7 +41,7 @@ jobs:
         chmod +x /usr/local/bin/coveralls
         coveralls --version
     - name: Report coverage to Coveralls
-      run: coveralls report ./coverage/lcov.info
+      run: coveralls report ./coverage/lcov.info -r ${{ secrets.COVERALLS_REPO_TOKEN}}
     - name: Convert coverage report to markdown
       uses: fingerprintjs/action-coverage-report-md@v2
       id: coverage

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -2,7 +2,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: 
+    branches:
       - dev
   pull_request:
     branches:

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - dev
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/test_nodejs.yml
+++ b/.github/workflows/test_nodejs.yml
@@ -43,16 +43,13 @@ jobs:
     - name: Report coverage to Coveralls
       run: coveralls report ./coverage/lcov.info -r ${{ secrets.COVERALLS_REPO_TOKEN}}
     - name: Convert coverage report to markdown
-      uses: fingerprintjs/action-coverage-report-md@v2
       id: coverage
-      with:
-        srcBasePath: './web'
-        textReportPath: './coverage/coverage.txt'
+      run: echo "MD_REPORT=$(cat "./coverage/coverage.txt")" >> $GITHUB_OUTPUT
     - name: Add coverage report to the PR
       uses: mshick/add-pr-comment@v2
       with:
-        message: ${{ steps.coverage.outputs.markdownReport }}
+        message: ${{ steps.coverage.outputs.MD_REPORT }}
     - name: Add coverage report to the job summary
       run: |
         echo "### Code Coverage" >> $GITHUB_STEP_SUMMARY
-        echo "${{ steps.coverage.outputs.markdownReport }}" >> $GITHUB_STEP_SUMMARY
+        echo "${{ steps.coverage.outputs.MD_REPORT }}" >> $GITHUB_STEP_SUMMARY

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -5,4 +5,8 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
+	coverageReporters: [
+		'lcov',
+		['text', { file: 'coverage.txt', path: './' }]
+	],
 };


### PR DESCRIPTION
### Note

L'output LCOV di Jest viene passato a Coveralls. Il secret è già stato definito.

Ora Jest produce anche un file di test, che viene poi usato per commentare la PR e la run, al fine di fornire riscontro leggibile.

Nel dettaglio:
- Configurato Jest per fornire anche testo
- Aggiunto test su Node.js 18 LTS
- Aggiunto trigger manuale per esecuzione GHA
- Aggiunta configurazione per Coveralls
- Commenta la PR e la run con il report

### Checklist

- [x] push di un commit `#minor`, `#patch`;
- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
